### PR TITLE
Enable cargo doc/check on non-Darwin platforms

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,11 @@
 extern crate gcc;
 
+use std::env;
+
 fn main() {
-    gcc::compile_library("libexception.a", &["extern/exception.m"]);
+    let target = env::var("TARGET").unwrap();
+
+    if target.ends_with("apple-darwin") || target.ends_with("apple-ios") {
+        gcc::compile_library("libexception.a", &["extern/exception.m"]);
+    }
 }


### PR DESCRIPTION
The build script causes cargo doc to fail on Linux, Windows, etc. by attempting to build an Objective-C library. This adds a target check to prevent doing this on unsupported platforms.