### PR TITLE
Add `no_std` support and migrate to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "objc_exception"
 version = "0.1.2"
 authors = ["Steven Sheldon"]
+edition = "2018"
 
 description = "Rust interface for Objective-C's throw and try/catch statements."
 keywords = ["objective-c", "osx", "ios"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Steven Sheldon"]
 
 description = "Rust interface for Objective-C's throw and try/catch statements."
 keywords = ["objective-c", "osx", "ios"]
+categories = ["development-tools::ffi", "no-std"]
 repository = "http://github.com/SSheldon/rust-objc-exception"
 documentation = "http://ssheldon.github.io/rust-objc/objc_exception/"
 license = "MIT"

--- a/extern/exception.m
+++ b/extern/exception.m
@@ -5,7 +5,8 @@ void RustObjCExceptionThrow(id exception) {
     @throw exception;
 }
 
-int RustObjCExceptionTryCatch(void (*try)(void *), void *context, id *error) {
+// We return `unsigned char`, since it is guaranteed to be an `u8` on all platforms
+unsigned char RustObjCExceptionTryCatch(void (*try)(void *), void *context, id *error) {
     @try {
         try(context);
         if (error) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern { }
 
 extern {
     fn RustObjCExceptionThrow(exception: *mut c_void);
-    fn RustObjCExceptionTryCatch(try: extern fn(*mut c_void),
+    fn RustObjCExceptionTryCatch(r#try: extern fn(*mut c_void),
             context: *mut c_void, error: *mut *mut c_void) -> u8; // std::os::raw::c_uchar
 }
 
@@ -64,7 +64,7 @@ unsafe fn try_no_ret<F>(closure: F) -> Result<(), *mut Exception>
 ///
 /// Unsafe because this encourages unwinding through the closure from
 /// Objective-C, which is not safe.
-pub unsafe fn try<F, R>(closure: F) -> Result<R, *mut Exception>
+pub unsafe fn r#try<F, R>(closure: F) -> Result<R, *mut Exception>
         where F: FnOnce() -> R {
     let mut value = None;
     let result = {
@@ -82,13 +82,13 @@ mod tests {
     use alloc::string::ToString;
     use core::ptr;
 
-    use super::{throw, try};
+    use super::{r#try, throw};
 
     #[test]
     fn test_try() {
         unsafe {
             let s = "Hello".to_string();
-            let result = try(move || {
+            let result = r#try(move || {
                 if s.len() > 0 {
                     throw(ptr::null_mut());
                 }
@@ -97,7 +97,7 @@ mod tests {
             assert!(result.unwrap_err() == ptr::null_mut());
 
             let mut s = "Hello".to_string();
-            let result = try(move || {
+            let result = r#try(move || {
                 s.push_str(", World!");
                 s
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
 //! Rust interface for Objective-C's `@throw` and `@try`/`@catch` statements.
 
-use std::mem;
-use std::os::raw::{c_int, c_void};
-use std::ptr;
+#![no_std]
+
+#[cfg(test)]
+extern crate alloc;
+
+use core::ffi::c_void;
+use core::mem;
+use core::ptr;
 
 #[link(name = "objc", kind = "dylib")]
 extern { }
@@ -10,7 +15,7 @@ extern { }
 extern {
     fn RustObjCExceptionThrow(exception: *mut c_void);
     fn RustObjCExceptionTryCatch(try: extern fn(*mut c_void),
-            context: *mut c_void, error: *mut *mut c_void) -> c_int;
+            context: *mut c_void, error: *mut *mut c_void) -> u8; // std::os::raw::c_uchar
 }
 
 /// An opaque type representing any Objective-C object thrown as an exception.
@@ -74,7 +79,9 @@ pub unsafe fn try<F, R>(closure: F) -> Result<R, *mut Exception>
 
 #[cfg(test)]
 mod tests {
-    use std::ptr;
+    use alloc::string::ToString;
+    use core::ptr;
+
     use super::{throw, try};
 
     #[test]


### PR DESCRIPTION
Notably, I had to change the return type of `RustObjCExceptionTryCatch` to an `unsigned char`/`u8`, since `int` is not guaranteed by the C standard to be `i32`.

Also bumps the edition field to 2018.