### PR TITLE
Don't include objc headers in `exception.m`

### DIFF
--- a/extern/exception.m
+++ b/extern/exception.m
@@ -1,5 +1,6 @@
-#include <objc/objc.h>
-#include <objc/NSObject.h>
+// Always available in Objective-C
+// See https://clang.llvm.org/docs/AutomaticReferenceCounting.html#arc-runtime-objc-retain
+id objc_retain(id value);
 
 void RustObjCExceptionThrow(id exception) {
     @throw exception;
@@ -9,12 +10,12 @@ int RustObjCExceptionTryCatch(void (*try)(void *), void *context, id *error) {
     @try {
         try(context);
         if (error) {
-            *error = nil;
+            *error = (id)0; // nil
         }
         return 0;
     } @catch (id exception) {
         if (error) {
-            *error = [exception retain];
+            *error = objc_retain(exception);
         }
         return 1;
     }


### PR DESCRIPTION
Fixes https://github.com/SSheldon/rust-objc-exception/issues/6 on my machine. Can you verify this @fenhl?

And also, it's faster to call `objc_retain` directly instead of using a selector.