### PR TITLE
Make `throw` more efficient

### DIFF
--- a/extern/exception.m
+++ b/extern/exception.m
@@ -1,10 +1,6 @@
 #include <objc/objc.h>
 #include <objc/NSObject.h>
 
-void RustObjCExceptionThrow(id exception) {
-    @throw exception;
-}
-
 int RustObjCExceptionTryCatch(void (*try)(void *), void *context, id *error) {
     @try {
         try(context);


### PR DESCRIPTION
I've also added a note about undefined behaviour, but note that the function also caused UB before (`RustObjCExceptionThrow` would need to be marked with `C-unwind`)